### PR TITLE
Code refactored so that scale HAL is better abstracted from the rest of the program

### DIFF
--- a/template-app/main/Scale.c
+++ b/template-app/main/Scale.c
@@ -1,5 +1,7 @@
 #include "Scale.h"
 
+#define ESP_INTR_FLAG_DEFAULT 0
+
 gptimer_handle_t gptimer = NULL;
 
 static QueueHandle_t gpio_evt_queue = NULL;
@@ -7,10 +9,15 @@ static const char *TAG = "example";
 
 gpio_config_t SCK;
 gpio_config_t DOUT;
+gpio_config_t HX711_ON;
 
 int i = 0;
 bool bit_read;
 uint8_t bit_postion;
+
+gpio_num_t scale_pin_on = 0;
+
+scale gas;
 
 
 void IRAM_ATTR gpio_isr_handler(void* arg)
@@ -37,70 +44,7 @@ void gpio_task_example(void* arg)
     }
 }
 
-void setup_scale( scale *scale){
-    
-    SCK.mode = GPIO_MODE_DEF_OUTPUT;
-    SCK.pin_bit_mask =(1ULL << SCK_PIN);
-
-    DOUT.mode = GPIO_MODE_DEF_INPUT;
-    DOUT.pin_bit_mask =(1ULL << DOUT_PIN);
-        //interrupt of rising edge
-    DOUT.intr_type = GPIO_INTR_NEGEDGE;
-    //enable pull-up mode
-    DOUT.pull_up_en = 1;
-    gpio_config(&DOUT);
-
-    
-
-    gpio_config(&SCK);
-    gpio_set_level(SCK_PIN,0);
-
-    //create a queue to handle gpio event from isr
-    gpio_evt_queue = xQueueCreate(10, sizeof(uint32_t));
-    //start gpio task
-
-
-    example_queue_element_t ele;
-
-    QueueHandle_t queue = xQueueCreate(10, sizeof(example_queue_element_t));
-
-
-    if (!queue) {
-        ESP_LOGE(TAG, "Creating queue failed");
-        return;
-    }
-
-    //ESP_LOGI(TAG, "Create timer handle");
-    //gptimer_handle_t gptimer = NULL;
-    
-    gptimer_config_t timer_config = {
-        .clk_src = GPTIMER_CLK_SRC_DEFAULT,
-        .direction = GPTIMER_COUNT_UP,
-        .resolution_hz = 10000000, // 10MHz, 1 tick=0.1us
-    };
-    
-    ESP_ERROR_CHECK(gptimer_new_timer(&timer_config, &gptimer));
-     
-    gptimer_event_callbacks_t cbs = {
-        .on_alarm = example_timer_on_alarm_cb_v2,
-    };
-    ESP_ERROR_CHECK(gptimer_register_event_callbacks(gptimer, &cbs, scale));
-    
-    ESP_LOGI(TAG, "Enable timer");
-    ESP_ERROR_CHECK(gptimer_enable(gptimer));
-
-   ESP_LOGI(TAG, "Start timer, auto-reload at alarm event");
-    gptimer_alarm_config_t alarm_config2 = {
-        .reload_count = 0,
-        .alarm_count = 50, // period = 5us
-        .flags.auto_reload_on_alarm = true,
-    };
-    ESP_ERROR_CHECK(gptimer_set_alarm_action(gptimer, &alarm_config2));
-    //ESP_ERROR_CHECK(gptimer_start(gptimer));*/
-}
-
-
-void read_scale( scale *scale){
+static void read_scale( scale *scale){
     if(i < (NUMBER_OF_PULSES*2)){
             if(i % 2 != 0){
                 gpio_set_level(SCK_PIN,1);
@@ -151,3 +95,101 @@ static bool IRAM_ATTR example_timer_on_alarm_cb_v2(gptimer_handle_t timer, const
 }
 
 
+static void setup_scale( scale *scale){
+    
+    SCK.mode = GPIO_MODE_DEF_OUTPUT;
+    SCK.pin_bit_mask =(1ULL << SCK_PIN);
+
+    DOUT.mode = GPIO_MODE_DEF_INPUT;
+    DOUT.pin_bit_mask =(1ULL << DOUT_PIN);
+        //interrupt of rising edge
+    DOUT.intr_type = GPIO_INTR_NEGEDGE;
+    //enable pull-up mode
+    DOUT.pull_up_en = 1;
+
+    // Configure on pin
+    HX711_ON.mode = GPIO_MODE_DEF_OUTPUT;
+    HX711_ON.pin_bit_mask =(1ULL << scale_pin_on);
+
+    gpio_config(&DOUT);
+
+    
+
+    gpio_config(&SCK);
+    gpio_set_level(SCK_PIN,0);
+
+    //create a queue to handle gpio event from isr
+    gpio_evt_queue = xQueueCreate(10, sizeof(uint32_t));
+    //start gpio task
+
+
+    QueueHandle_t queue = xQueueCreate(10, sizeof(example_queue_element_t));
+
+
+    if (!queue) {
+        ESP_LOGE(TAG, "Creating queue failed");
+        return;
+    }
+
+    //ESP_LOGI(TAG, "Create timer handle");
+    //gptimer_handle_t gptimer = NULL;
+    
+    gptimer_config_t timer_config = {
+        .clk_src = GPTIMER_CLK_SRC_DEFAULT,
+        .direction = GPTIMER_COUNT_UP,
+        .resolution_hz = 10000000, // 10MHz, 1 tick=0.1us
+    };
+    
+    ESP_ERROR_CHECK(gptimer_new_timer(&timer_config, &gptimer));
+     
+    gptimer_event_callbacks_t cbs = {
+        .on_alarm = example_timer_on_alarm_cb_v2,
+    };
+    ESP_ERROR_CHECK(gptimer_register_event_callbacks(gptimer, &cbs, scale));
+    
+    ESP_LOGI(TAG, "Enable timer");
+    ESP_ERROR_CHECK(gptimer_enable(gptimer));
+
+   ESP_LOGI(TAG, "Start timer, auto-reload at alarm event");
+    gptimer_alarm_config_t alarm_config2 = {
+        .reload_count = 0,
+        .alarm_count = 50, // period = 5us
+        .flags.auto_reload_on_alarm = true,
+    };
+    ESP_ERROR_CHECK(gptimer_set_alarm_action(gptimer, &alarm_config2));
+    //ESP_ERROR_CHECK(gptimer_start(gptimer));*/
+
+    //install gpio isr service
+    gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT);
+     //hook isr handler for specific gpio pin
+    gpio_isr_handler_add(DOUT_PIN, gpio_isr_handler, (void*) &gas);
+}
+
+
+void scale_reset(void){
+    gas.byte =0;
+    gas.flag = 0;
+}
+
+
+bool scale_is_ready(){
+  return (gas.flag == 1);
+}
+
+uint8_t scale_get_byte(){
+  return gas.byte;
+}
+
+void scale_init(gpio_num_t pin_on)
+{
+
+  scale_pin_on = pin_on;
+
+  gas.flag = 1;
+
+  // Setup scale
+  setup_scale(&gas);
+
+  // Init task to read (and probably convert) scale
+  xTaskCreate(&gpio_task_example, "gpio_task_example", 2048, NULL, 10, NULL);
+}

--- a/template-app/main/Scale.h
+++ b/template-app/main/Scale.h
@@ -16,7 +16,6 @@
     #include <inttypes.h>
     #include "driver/gpio.h"
 
-   
   
 
     typedef  struct {
@@ -29,11 +28,10 @@
         uint64_t event_count;
     } example_queue_element_t;
 
-    void setup_scale(scale *scale);
-    void read_scale( scale *scale);
-    static bool IRAM_ATTR example_timer_on_alarm_cb_v2(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_data);
-    void IRAM_ATTR gpio_isr_handler(void* arg);
-    void gpio_task_example(void* arg);
+    void scale_init(gpio_num_t pin_on);
+    void scale_reset(void);
+    bool scale_is_ready();
+    uint8_t scale_get_byte();
 
 
 #endif 

--- a/template-app/main/main.c
+++ b/template-app/main/main.c
@@ -15,53 +15,35 @@
 #define ZERO_LOAD 16740795.0
 #define Kilo 16679106.0
 
-gpio_config_t HX711_ON;
-scale gas;
-
-
-#define ESP_INTR_FLAG_DEFAULT 0
-
 
 void  Print(void *pvParamters){
     while(1){
-     if(gas.flag == 1){
+
+     if(scale_is_ready()){
        // printf("Decimal: %lu, Hex: %lx\n", byte, byte);
-       int32_t a = (gas.byte-ZERO_LOAD) ;
+       int32_t a = (uint32_t)scale_get_byte()  - ZERO_LOAD;
        double b = a*(1/(Kilo-ZERO_LOAD));
        printf("%f\n" ,b);
 
-        gas.byte =0;
-        gas.flag = 0;
+       scale_reset();
     }
 
-        vTaskDelay(10);
+    vTaskDelay(10);
     }
 }
 
 
 void app_main(void)
 {
-    HX711_ON.mode = GPIO_MODE_DEF_OUTPUT;
-    HX711_ON.pin_bit_mask =(1ULL << HX711_ON_PIN);
 
-    gas.flag = 1;
+    scale_init(HX711_ON_PIN);
 
-    setup_scale(&gas);
-
-    
-    //install gpio isr service
-    gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT);
-     //hook isr handler for specific gpio pin
-    gpio_isr_handler_add(DOUT_PIN, gpio_isr_handler, (void*) &gas);
-
-    
-    xTaskCreate(&gpio_task_example, "gpio_task_example", 2048, NULL, 10, NULL);
+    // Create task to print value (you can do this in the main task but whatever)
     xTaskCreate(&Print, "Print", 2048, NULL, 1, NULL);
 
     while (1)
     {
         vTaskDelay(1000);
-
     }
     
 }


### PR DESCRIPTION
 (Not tested)

No me gusta, todavía se puede abstraer más como por ejemplo metiendo dentro la función de "conversión":
```C
void  Print(void *pvParamters){
    while(1){

     if(scale_is_ready()){
       // printf("Decimal: %lu, Hex: %lx\n", byte, byte);
       int32_t a = (uint32_t)scale_get_byte()  - ZERO_LOAD;
       double b = a*(1/(Kilo-ZERO_LOAD));
       printf("%f\n" ,b);

       scale_reset();
    }

    vTaskDelay(10);
    }
}
```
Y que el programa principal llame a un método scale_get_kg() o algo así y te devuelva directamente en Kg.

Prueba y me dises